### PR TITLE
Redesign `recurrence`

### DIFF
--- a/mathtools/__init__.py
+++ b/mathtools/__init__.py
@@ -7,10 +7,10 @@ from operator import mul
 from typing import overload, Any, Iterable, Union
 
 __all__ = [
-    "combinatorics",
-    "functional",
-    "iterator",
-    "number_theory"
+    'combinatorics',
+    'functional',
+    'iterator',
+    'number_theory'
 ]
 
 #pylint: disable=unused-argument,function-redefined

--- a/mathtools/__init__.py
+++ b/mathtools/__init__.py
@@ -9,6 +9,7 @@ from typing import overload, Any, Iterable, Union
 __all__ = [
     "combinatorics",
     "functional",
+    "iterator",
     "number_theory"
 ]
 

--- a/mathtools/combinatorics.py
+++ b/mathtools/combinatorics.py
@@ -1,5 +1,7 @@
 from math import factorial
+from operator import add
 from typing import Callable, Iterator, List, Optional, TypeVar
+
 from mathtools import product
 
 _T = TypeVar('_T')
@@ -44,13 +46,7 @@ def fibonacci_numbers() -> Iterator[int]:
     >>> list(itertools.islice(fib, 5))
     [1, 2, 3, 5, 8]
     """
-    last1 = 1
-    last2 = 0
-    while True:
-        fib = last1 + last2
-        last2 = last1
-        last1 = fib
-        yield fib
+    return recurrence([1, 2], add)
 
 def binomial_coefficient(n: int, k: int) -> int:
     """

--- a/mathtools/combinatorics.py
+++ b/mathtools/combinatorics.py
@@ -1,21 +1,17 @@
 from math import factorial
 from operator import add
-from typing import Callable, Iterator, List, Optional, TypeVar
+from typing import Callable, Iterator, List, TypeVar
 
 from mathtools import product
 
 _T = TypeVar('_T')
 
-def recurrence(start: List[_T], func: Callable[..., Optional[_T]]) -> Iterator[_T]:
+def recurrence(start: List[_T], func: Callable[..., _T]) -> Iterator[_T]:
     """
     Return an `Iterator` beginning with `start` where each element is created
     by applying `func` to the previous `len(start)` elements.
 
     `func()` should take `len(start)` parameters of type `_T`.
-    Iteration stops when a `None` value is reached.
-
-    >>> list(recurrence([1], lambda x: x + 1 if x < 5 else None))
-    [1, 2, 3, 4, 5]
 
     >>> from .iterator import take
     >>> it = recurrence([1], lambda x: x * 2)

--- a/mathtools/combinatorics.py
+++ b/mathtools/combinatorics.py
@@ -1,31 +1,39 @@
 from math import factorial
-from typing import Callable, Iterator, Optional, TypeVar
+from typing import Callable, Iterator, List, Optional, TypeVar
 from mathtools import product
 
 _T = TypeVar('_T')
 
-def recurrence(start: _T, func: Callable[[_T], Optional[_T]]) -> Iterator[_T]:
+def recurrence(start: List[_T], func: Callable[..., Optional[_T]]) -> Iterator[_T]:
     """
     Return an `Iterator` beginning with `start` where each element is created
-    by applying `func` to the previous element.
+    by applying `func` to the previous `arity` elements.
 
+    `func()` should take `arity` parameters of type `_T`.
     Iteration stops when a `None` value is reached.
 
-    >>> list(recurrence(None, lambda: 100))
-    []
+    >>> import itertools
+    >>> it = recurrence([], lambda: 100)
+    >>> list(itertools.islice(it, 3))
+    [100, 100, 100]
 
-    >>> list(recurrence(1, lambda x: x + 1 if x < 5 else None))
+    >>> list(recurrence([1], lambda x: x + 1 if x < 5 else None))
     [1, 2, 3, 4, 5]
 
     >>> import itertools
-    >>> it = recurrence(1, lambda x: x * 2)
+    >>> it = recurrence([1], lambda x: x * 2)
     >>> list(itertools.islice(it, 5))
     [1, 2, 4, 8, 16]
     """
-    current: Optional[_T] = start
-    while current is not None:
-        yield current
-        current = func(current)
+    window = start
+    yield from iter(start)
+
+    value = func(*window)
+    while value is not None:
+        yield value
+        window += [value]
+        window = window[1:]
+        value = func(*window)
 
 def fibonacci_numbers() -> Iterator[int]:
     """

--- a/mathtools/combinatorics.py
+++ b/mathtools/combinatorics.py
@@ -9,9 +9,9 @@ _T = TypeVar('_T')
 def recurrence(start: List[_T], func: Callable[..., Optional[_T]]) -> Iterator[_T]:
     """
     Return an `Iterator` beginning with `start` where each element is created
-    by applying `func` to the previous `arity` elements.
+    by applying `func` to the previous `len(start)` elements.
 
-    `func()` should take `arity` parameters of type `_T`.
+    `func()` should take `len(start)` parameters of type `_T`.
     Iteration stops when a `None` value is reached.
 
     >>> import itertools

--- a/mathtools/combinatorics.py
+++ b/mathtools/combinatorics.py
@@ -14,17 +14,12 @@ def recurrence(start: List[_T], func: Callable[..., Optional[_T]]) -> Iterator[_
     `func()` should take `len(start)` parameters of type `_T`.
     Iteration stops when a `None` value is reached.
 
-    >>> import itertools
-    >>> it = recurrence([], lambda: 100)
-    >>> list(itertools.islice(it, 3))
-    [100, 100, 100]
-
     >>> list(recurrence([1], lambda x: x + 1 if x < 5 else None))
     [1, 2, 3, 4, 5]
 
-    >>> import itertools
+    >>> from .iterator import take
     >>> it = recurrence([1], lambda x: x * 2)
-    >>> list(itertools.islice(it, 5))
+    >>> take(5, it)
     [1, 2, 4, 8, 16]
     """
     window = start

--- a/mathtools/iterator.py
+++ b/mathtools/iterator.py
@@ -1,0 +1,8 @@
+import itertools
+from typing import Iterable, List, TypeVar
+
+_T = TypeVar('_T')
+
+def take(n: int, iterable: Iterable[_T]) -> List[_T]:
+    "Return the first `n` items of the iterable as a list"
+    return list(itertools.islice(iterable, n))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mathtools',
-    version='0.4.1',
+    version='0.4.0',
     description='A library for doing discrete math in Python',
     packages=['mathtools'],
     python_requires='~=3.6',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mathtools',
-    version='0.4.0',
+    version='0.5.0',
     description='A library for doing discrete math in Python',
     packages=['mathtools'],
     python_requires='~=3.6',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mathtools',
-    version='0.4.0',
+    version='0.4.1',
     description='A library for doing discrete math in Python',
     packages=['mathtools'],
     python_requires='~=3.6',

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -1,4 +1,13 @@
-from mathtools.combinatorics import binomial_coefficient
+from mathtools.iterator import take
+from mathtools.combinatorics import binomial_coefficient, recurrence
+
+def test_recurrence() -> None:
+    it = recurrence([], lambda: 100)
+    assert take(3, it) == [100, 100, 100]
+
+    it = recurrence(['a', 'b', 'c'], lambda x, y, z: x + y + z)
+    assert take(5, it) == ['a', 'b', 'c', 'abc', 'bcabc']
+
 
 def test_binomial_coefficient() -> None:
     assert binomial_coefficient(1, 0) == 1

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -5,9 +5,11 @@ def test_recurrence() -> None:
     it = recurrence([], lambda: 100)
     assert take(3, it) == [100, 100, 100]
 
+    it = recurrence([1], lambda x: x + 1)
+    assert take(5, it) == [1, 2, 3, 4, 5]
+
     it = recurrence(['a', 'b', 'c'], lambda x, y, z: x + y + z)
     assert take(5, it) == ['a', 'b', 'c', 'abc', 'bcabc']
-
 
 def test_binomial_coefficient() -> None:
     assert binomial_coefficient(1, 0) == 1

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -12,14 +12,14 @@ def test_recurrence() -> None:
         return x + 1
 
     it1 = recurrence([1], plus1)
-    # it = recurrence([1], lambda x: x + 1)
+    # it1 = recurrence([1], lambda x: x + 1)
     assert take(5, it1) == [1, 2, 3, 4, 5]
 
     def concat(x: str, y: str, z: str) -> str:
         return x + y + z
 
     it2 = recurrence(['a', 'b', 'c'], concat)
-    # it = recurrence(['a', 'b', 'c'], lambda x, y, z: x + y + z)
+    # it2 = recurrence(['a', 'b', 'c'], lambda x, y, z: x + y + z)
     assert take(5, it2) == ['a', 'b', 'c', 'abc', 'bcabc']
 
 def test_binomial_coefficient() -> None:

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -1,15 +1,26 @@
+from typing import cast, List
+
 from mathtools.iterator import take
 from mathtools.combinatorics import binomial_coefficient, recurrence
 
 def test_recurrence() -> None:
-    it = recurrence([], lambda: 100)
-    assert take(3, it) == [100, 100, 100]
+    it0 = recurrence(cast(List[int], []), lambda: 100)
+    assert take(3, it0) == [100, 100, 100]
 
-    it = recurrence([1], lambda x: x + 1)
-    assert take(5, it) == [1, 2, 3, 4, 5]
+    # Mypy seems to struggle with generics + lambdas
+    def plus1(x: int) -> int:
+        return x + 1
 
-    it = recurrence(['a', 'b', 'c'], lambda x, y, z: x + y + z)
-    assert take(5, it) == ['a', 'b', 'c', 'abc', 'bcabc']
+    it1 = recurrence([1], plus1)
+    # it = recurrence([1], lambda x: x + 1)
+    assert take(5, it1) == [1, 2, 3, 4, 5]
+
+    def concat(x: str, y: str, z: str) -> str:
+        return x + y + z
+
+    it2 = recurrence(['a', 'b', 'c'], concat)
+    # it = recurrence(['a', 'b', 'c'], lambda x, y, z: x + y + z)
+    assert take(5, it2) == ['a', 'b', 'c', 'abc', 'bcabc']
 
 def test_binomial_coefficient() -> None:
     assert binomial_coefficient(1, 0) == 1


### PR DESCRIPTION
* Take higher-arity functions
* Don't use `Optional` to stop iteration.  This is still kind of close coupling, and shouldn't be needed since the iteration is lazy -- just stop the iteration externally.  It also makes it complicated when dealing with functions that take `Optional[_T]` as a parameter type.